### PR TITLE
add encodings so we dont get errors

### DIFF
--- a/calcElasticCacheStats.py
+++ b/calcElasticCacheStats.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # input params
 # Input File path to be processed
 

--- a/planRedisCluster.py
+++ b/planRedisCluster.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # input params
 # Input File path
 

--- a/pullElasticCacheStats.py
+++ b/pullElasticCacheStats.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # input params
 # path to the config file, see pullStatsConfig.json
 


### PR DESCRIPTION
without setting the encoding we get runtime errors:

```
$ python calcElasticCacheStats.py
  File "calcElasticCacheStats.py", line 43
SyntaxError: Non-ASCII character '\xc3' in file calcElasticCacheStats.py on line 43, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

So to be consistent I've added the encoding 